### PR TITLE
Fixes Windows compatibility

### DIFF
--- a/info.rkt
+++ b/info.rkt
@@ -2,5 +2,4 @@
 
 (define collection 'multi)
 (define deps '("base"))
-(define version "0.3")
-
+(define version "0.4")

--- a/tzinfo/tzdata.rkt
+++ b/tzinfo/tzdata.rkt
@@ -1,0 +1,7 @@
+#lang racket/base
+
+(require racket/runtime-path
+         (for-syntax racket/base))
+(provide tzdata-zoneinfo-dir)
+
+(define-runtime-path tzdata-zoneinfo-dir (build-path "private" "data"))


### PR DESCRIPTION
Also, allow data to be embedded in an executable with an
explicit use of raco exe ++libs tzinfo/tzdata.

The previous versions were indended to work without an
explicit switch, but they did not work.