### PR TITLE
Copy zoneinfo files into shared directory on package install

### DIFF
--- a/build.rkt
+++ b/build.rkt
@@ -69,7 +69,8 @@
                       ";; versions.\n"))
       (writeln `(define iana-tz-version ,(version)))
       (writeln `(define tzdata-zoneinfo-dir "tzdata/zoneinfo"))
-      (writeln `(define tzdata-zoneinfo-module-path '(lib "tzinfo/tzdata/zoneinfo"))))))
+      (writeln `(define tzdata-zoneinfo-module-path '(lib "tzinfo/tzdata/zoneinfo")))
+      (writeln `(define copy-shared-files '("tzdata"))))))
 
 (define (run)
   (clean)
@@ -80,3 +81,6 @@
   (install-data)
   (install-info)
   (clean))
+
+(module* main #f
+  (run))

--- a/info.rkt
+++ b/info.rkt
@@ -2,5 +2,4 @@
 
 (define collection 'multi)
 (define deps '("base"))
-(define version "0.4")
-
+(define version "0.5")

--- a/tzinfo/info.rkt
+++ b/tzinfo/info.rkt
@@ -6,3 +6,4 @@
 (define iana-tz-version "2021e")
 (define tzdata-zoneinfo-dir "tzdata/zoneinfo")
 (define tzdata-zoneinfo-module-path (quote (lib "tzinfo/tzdata/zoneinfo")))
+(define copy-shared-files (quote ("tzdata")))


### PR DESCRIPTION
This will allow the tzinfo package to define a runtime path
to the files, allowing them to be used in standalone applications.
The current way that tzdata communicates the location of these
files is via `find-relevant-directories`, but that doesn't
work in the context of a standalone executable.

See the following racket-users mailing list discussion for
details:
https://groups.google.com/g/racket-users/c/_2lHI5SkqJo/m/XubQz-waBgAJ